### PR TITLE
UserリポジトリのfindAll()をモデルでなくエンティティを返却するように修正

### DIFF
--- a/app/Repositories/User/UserRepository.php
+++ b/app/Repositories/User/UserRepository.php
@@ -28,7 +28,12 @@ class UserRepository implements IUserRepository
      */
     public function findAll(): Collection
     {
-        return UserModel::all();
+        return UserModel::all()->map(function (UserModel $userModel) {
+            return User::reconstruct(
+                $userModel->id,
+                $userModel->role
+            );
+        });
     }
 
     public function update(User $user): void


### PR DESCRIPTION
`app/UseCases/Shift/CreateUseCase.php
`       
内の以下にて取得する$usersがエンティティである必要があるため修正しました
 $users = $this->userRepository->findAll();
