### PR TITLE
Refactor shift management to use date strings instead of year and mon…

### DIFF
--- a/app/Livewire/Shift/Show.php
+++ b/app/Livewire/Shift/Show.php
@@ -4,7 +4,7 @@ namespace app\Livewire\Shift;
 
 use app\UseCases\Shift\ShowUseCase;
 use app\UseCases\Shift\ShowUseCaseDto;
-use DateTimeImmutable;
+use DateTime;
 use Illuminate\Contracts\View\View;
 use Illuminate\Support\Collection;
 use Livewire\Component;
@@ -16,10 +16,9 @@ class Show extends Component
      */
     public Collection $shifts;
 
-    public int $year;
+    public string $current_start_date;
 
-    public int $month;
-
+    public string $current_end_date;
     private ShowUseCase $showUseCase;
 
     public function boot(ShowUseCase $showUseCase): void
@@ -29,11 +28,11 @@ class Show extends Component
 
     public function mount(): void
     {
-        $now = new DateTimeImmutable;
-        $this->year = $this->year ?? (int) $now->format('Y');
-        $this->month = $this->month ?? (int) $now->format('m');
+        $now = new DateTime;
+        $this->current_start_date = $now->format('Y-m-01');
+        $this->current_end_date = $now->format('Y-m-t');
 
-        $dto = ShowUseCaseDto::create($this->year, $this->month);
+        $dto = ShowUseCaseDto::create($this->current_start_date, $this->current_end_date);
 
         $this->shifts = ($this->showUseCase)($dto);
     }

--- a/app/UseCases/Shift/CreateUseCase.php
+++ b/app/UseCases/Shift/CreateUseCase.php
@@ -26,24 +26,24 @@ class CreateUseCase
      */
     public function __invoke(CreateUseCaseDto $createUseCaseDto): Collection
     {
-        $shiftCollection = new Collection;
+        $shift_collection = new Collection;
         $users = $this->userRepository->findAll();
-        $date = new DateTime($createUseCaseDto->startDate);
-        $endDate = new DateTimeImmutable($createUseCaseDto->endDate);
-        $previousShift = $this->shiftRepository->getShiftByDate($date->modify('-1 day'));
-        $confirmedNextShift = null;
+        $date = new DateTime($createUseCaseDto->start_date);
+        $end_date = new DateTimeImmutable($createUseCaseDto->end_date);
+        $previous_shift = $this->shiftRepository->getShiftByDate($date->modify('-1 day'));
+        $confirmed_next_shift = null;
         // 開始日〜終了日まで1日ずつ加算しながら日ごとのシフトを作成する
-        for (; $date->diff($endDate)->d !== 0; $date->modify('+1 day')) {
-            if ($date->format('Y-m-d') === $endDate->format('Y-m-d')) {
-                $confirmedNextShift = $this->shiftRepository->getShiftByDate($date->modify('+1 day'));
+        for (; $date->diff($end_date)->d !== 0; $date->modify('+1 day')) {
+            if ($date->format('Y-m-d') === $end_date->format('Y-m-d')) {
+                $confirmed_next_shift = $this->shiftRepository->getShiftByDate($date->modify('+1 day'));
             }
-            $entity = $this->shiftFactory->create($date, $users, $previousShift, $confirmedNextShift);
-            $shiftCollection->add($entity);
-            $previousShift = $entity;
+            $entity = $this->shiftFactory->create($date, $users, $previous_shift, $confirmed_next_shift);
+            $shift_collection->add($entity);
+            $previous_shift = $entity;
         }
 
         $errors = [];
-        foreach ($shiftCollection as $shift) {
+        foreach ($shift_collection as $shift) {
             $errors = [
                 ...$errors,
                 ...$this->createShiftUserRoleSpecification->getViolations(
@@ -55,12 +55,12 @@ class CreateUseCase
         }
         $errors = [
             ...$errors,
-            ...$this->createShiftContinueSpecification->getViolations($shiftCollection),
+            ...$this->createShiftContinueSpecification->getViolations($shift_collection),
         ];
         if ($errors) {
             throw new \InvalidArgumentException(implode(PHP_EOL, $errors));
         }
 
-        return $shiftCollection;
+        return $shift_collection;
     }
 }

--- a/app/UseCases/Shift/CreateUseCaseDto.php
+++ b/app/UseCases/Shift/CreateUseCaseDto.php
@@ -5,17 +5,17 @@ namespace app\UseCases\Shift;
 class CreateUseCaseDto
 {
     private function __construct(
-        public readonly string $startDate,
-        public readonly string $endDate,
+        public readonly string $start_date,
+        public readonly string $end_date,
     ) {}
 
     public static function create(
-        string $startDate,
-        string $endDate,
+        string $start_date,
+        string $end_date,
     ): self {
         return new CreateUseCaseDto(
-            $startDate,
-            $endDate,
+            $start_date,
+            $end_date,
         );
     }
 }

--- a/app/UseCases/Shift/ShowUseCase.php
+++ b/app/UseCases/Shift/ShowUseCase.php
@@ -15,19 +15,18 @@ class ShowUseCase
     /**
      * @return Collection<int, \app\Domains\Shift\Shift>
      */
-    public function __invoke(ShowUseCaseDto $getUseCaseDto): Collection
+    public function __invoke(ShowUseCaseDto $showUseCaseDto): Collection
     {
         try {
-            $firstDayOfMonth = new DateTimeImmutable("{$getUseCaseDto->year}-{$getUseCaseDto->month}-01");
+            $firstDayOfMonth = new DateTimeImmutable($showUseCaseDto->start_date);
+            $endDayOfMonth = new DateTimeImmutable($showUseCaseDto->end_date);
         } catch (\Exception $e) {
             throw new \InvalidArgumentException('正しい形式の日付を指定してください。');
         }
-        $lastDayOfMonth = $firstDayOfMonth
-            ->modify('first day of next month')
-            ->modify('-1 day');
 
-        $shiftCollection = $this->shiftRepository->getShiftsByPeriod($firstDayOfMonth, $lastDayOfMonth);
-
-        return $shiftCollection;
+        return $this->shiftRepository->getShiftsByPeriod(
+            $firstDayOfMonth,
+            $endDayOfMonth,
+        );
     }
 }

--- a/app/UseCases/Shift/ShowUseCaseDto.php
+++ b/app/UseCases/Shift/ShowUseCaseDto.php
@@ -5,17 +5,17 @@ namespace app\UseCases\Shift;
 class ShowUseCaseDto
 {
     private function __construct(
-        public readonly int $year,
-        public readonly int $month
+        public readonly string $start_date,
+        public readonly string $end_date
     ) {}
 
     public static function create(
-        int $year,
-        int $month
+        string $start_date,
+        string $end_date,
     ): self {
         return new ShowUseCaseDto(
-            $year,
-            $month
+            $start_date,
+            $end_date,
         );
     }
 }

--- a/resources/views/livewire/shift/show.blade.php
+++ b/resources/views/livewire/shift/show.blade.php
@@ -5,7 +5,7 @@
         </h2>
         <div class="flex justify-between">
             <x-m-primary-button>
-                <a href="{{ route('shift.edit') }}">{{ __('Shift') }}{{ __('Edit') }}</a>
+                <a href="{{ route('shift.edit', ['start_date' => $current_start_date, 'end_date' => $current_end_date], false) }}">{{ __('Shift') }}{{ __('Edit') }}</a>
             </x-m-primary-button>
             <livewire:shift.create />
         </div>


### PR DESCRIPTION
…th integers

- Updated Show component to use current_start_date and current_end_date for shift display.
- Modified CreateUseCase and ShowUseCase to accept start_date and end_date as strings.
- Adjusted CreateUseCaseDto and ShowUseCaseDto to reflect changes in date handling.
- Updated view to pass date parameters correctly for editing shifts.